### PR TITLE
Fix additional SEO issues from Google Search Console

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.3] - 2026-02-28
 ### Fixed
 - Fixed broken /contact link on 404 page (page was deleted, now links to /blog)
-- Added Netlify _redirects for deleted pages (/contact, /samples, old starter posts) to resolve Google Search Console 404 errors
+- Added Netlify _redirects for deleted pages (/contact, /samples, /renew-or-boycott, old starter posts) to resolve Google Search Console 404 errors
 - Added robots.txt with sitemap reference for better SEO crawling
+- Added canonical URL tags to SEO component to help Google index pages
+- Fixed malformed bijantech.com link in about.md (was relative, causing /about/bijantech.com 404s)
+- Fixed typo "principle" → "principal" in about page
 - Removed stale contact page definition from Netlify CMS config
 - Removed orphaned template files (samples.js, contact-page.js.bak)
 - Removed duplicate gatsby-plugin-netlify entry in gatsby-config.js

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -27,6 +27,7 @@ const SEO = ({ title, description, image, article }) => {
   return (
     <Helmet title={seo.title} titleTemplate={titleTemplate}>
       <html lang="en-US" />
+      <link rel="canonical" href={seo.url} />
       <link rel="alternate" href={seo.url} hreflang="en-us" />
       <link rel="alternate" href={seo.url} hreflang="en" />
       <link rel="alternate" href={seo.url} hreflang="x-default" />

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -16,4 +16,4 @@ He has been living in Bali, Indonesia since August of 2025.
 
 You can reach him via email at bijan@bijanrahnamai.com<br>
 
-He works as a principle engineer and can find his consulting services at [bijantech.com](bijantech.com)
+He works as a principal engineer and can find his consulting services at [bijantech.com](https://bijantech.com)

--- a/static/_redirects
+++ b/static/_redirects
@@ -2,7 +2,8 @@
 /contact          /about    301
 /samples          /blog     301
 
-# Redirects for deleted blog posts (old starter content)
+# Redirects for deleted blog posts
+/renew-or-boycott          /blog    301
 /desk-for-minimalists      /blog    301
 /my-pretty-white-shoes     /blog    301
 /paper-boat                /blog    301


### PR DESCRIPTION
## Summary
- Added `<link rel="canonical">` tags to SEO component to help Google index crawled-but-not-indexed pages
- Fixed malformed `bijantech.com` link in about page (was a relative URL causing `/about/bijantech.com` and `/bijantech.com` 404s)
- Added 301 redirect for deleted `/renew-or-boycott` blog post
- Fixed typo "principle" → "principal" in about page

## Context
Google Search Console reported:
- **Crawled - not indexed**: `/travel-is-the-university-of-life/`, `/learning-from-failure/` — missing canonical URLs
- **404 errors**: `/renew-or-boycott`, `/about/bijantech.com`, `/bijantech.com` — deleted post + malformed link
- **Page with redirect**: trailing slash / http→https redirects — expected behavior, no action needed

## Test plan
- [ ] Verify canonical tags appear in page source
- [ ] Confirm `/renew-or-boycott` redirects to `/blog`
- [ ] Confirm about page link to bijantech.com works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)